### PR TITLE
[WIP]add Dockerfile and docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.5.4-alpine
+MAINTAINER Takeshi KONDO <take.she12@gmail.com>
+
+RUN apk --update add git && rm -rf /var/cache/apk/*
+RUN git clone https://github.com/takeshe12/spiceshare.git
+
+WORKDIR spiceshare
+RUN pip install -r requirements.txt -r test_requirements.txt
+
+CMD python spiceshare/app.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  flask:
+    image: python:3.5.4-alpine
+    ports:
+     - "5000:5000"
+    volumes:
+     - .:/db
+    depends_on:
+     - mongo
+    links:
+    - mongo
+  mongo:
+    image: mongo:3.4.4
+    ports:
+      - "27017:27017"
+    command: mongod --port 27017


### PR DESCRIPTION
* 'docker-compose up' didn't work....

```
vagrant@docker:~/spiceshare$ docker-compose up
Starting spiceshare_mongo_1 ... 
Starting spiceshare_mongo_1 ... done
Starting spiceshare_flask_1 ... 
Starting spiceshare_flask_1 ... done
Attaching to spiceshare_mongo_1, spiceshare_flask_1
mongo_1  | 2017-09-21T04:04:18.353+0000 I CONTROL  [initandlisten] MongoDB starting : pid=1 port=27017 dbpath=/data/db 64-bit host=b71624caee3d
mongo_1  | 2017-09-21T04:04:18.353+0000 I CONTROL  [initandlisten] db version v3.4.4
mongo_1  | 2017-09-21T04:04:18.353+0000 I CONTROL  [initandlisten] git version: 888390515874a9debd1b6c5d36559ca86b44babd
mongo_1  | 2017-09-21T04:04:18.353+0000 I CONTROL  [initandlisten] OpenSSL version: OpenSSL 1.0.1t  3 May 2016
mongo_1  | 2017-09-21T04:04:18.353+0000 I CONTROL  [initandlisten] allocator: tcmalloc
mongo_1  | 2017-09-21T04:04:18.353+0000 I CONTROL  [initandlisten] modules: none
mongo_1  | 2017-09-21T04:04:18.353+0000 I CONTROL  [initandlisten] build environment:
mongo_1  | 2017-09-21T04:04:18.353+0000 I CONTROL  [initandlisten]     distmod: debian81
mongo_1  | 2017-09-21T04:04:18.353+0000 I CONTROL  [initandlisten]     distarch: x86_64
mongo_1  | 2017-09-21T04:04:18.353+0000 I CONTROL  [initandlisten]     target_arch: x86_64
mongo_1  | 2017-09-21T04:04:18.353+0000 I CONTROL  [initandlisten] options: { net: { port: 27017 } }
mongo_1  | 2017-09-21T04:04:18.358+0000 I -        [initandlisten] Detected data files in /data/db created by the 'wiredTiger' storage engine, so setting the active storage engine to 'wiredTiger'.
mongo_1  | 2017-09-21T04:04:18.358+0000 I STORAGE  [initandlisten] 
mongo_1  | 2017-09-21T04:04:18.358+0000 I STORAGE  [initandlisten] ** WARNING: Using the XFS filesystem is strongly recommended with the WiredTiger storage engine
mongo_1  | 2017-09-21T04:04:18.358+0000 I STORAGE  [initandlisten] **          See http://dochub.mongodb.org/core/prodnotes-filesystem
mongo_1  | 2017-09-21T04:04:18.358+0000 I STORAGE  [initandlisten] wiredtiger_open config: create,cache_size=256M,session_max=20000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000),checkpoint=(wait=60,log_size=2GB),statistics_log=(wait=0),
mongo_1  | 2017-09-21T04:04:18.675+0000 I CONTROL  [initandlisten] 
mongo_1  | 2017-09-21T04:04:18.675+0000 I CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
mongo_1  | 2017-09-21T04:04:18.675+0000 I CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
mongo_1  | 2017-09-21T04:04:18.675+0000 I CONTROL  [initandlisten] 
mongo_1  | 2017-09-21T04:04:18.677+0000 I FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/data/db/diagnostic.data'
mongo_1  | 2017-09-21T04:04:18.678+0000 I NETWORK  [thread1] waiting for connections on port 27017
spiceshare_flask_1 exited with code 0
```